### PR TITLE
Splash Screen Functionality/ Layout Creation  

### DIFF
--- a/code/.idea/gradle.xml
+++ b/code/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".activitys.SplashActivity"
-            android:label="@string/app_splash"
+            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
+            android:name=".activitys.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
@@ -18,6 +18,11 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".activitys.SplashActivity"
+            android:label="Splash Activity"
+            android:theme="@style/AppTheme.NoActionBar">
         </activity>
     </application>
 

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".activitys.MainActivity"
-            android:label="@string/app_name"
+            android:name=".activitys.SplashActivity"
+            android:label="@string/app_splash"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -20,8 +20,8 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".activitys.SplashActivity"
-            android:label="Splash Activity"
+            android:name=".activitys.MainActivity"
+            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
     </application>

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/MainActivity.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.nicholasrutherford.distractme
+package com.nicholasrutherford.distractme.activitys
 
 import android.os.Bundle
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -6,8 +6,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import androidx.viewpager.widget.ViewPager
 import androidx.appcompat.app.AppCompatActivity
-import android.view.Menu
-import android.view.MenuItem
+import com.nicholasrutherford.distractme.R
 import com.nicholasrutherford.distractme.ui.main.SectionsPagerAdapter
 
 class MainActivity : AppCompatActivity() {

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
@@ -1,0 +1,6 @@
+package com.nicholasrutherford.distractme.activitys
+
+import androidx.appcompat.app.AppCompatActivity
+
+class SplashActivity : AppCompatActivity() {
+}

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
@@ -1,6 +1,33 @@
 package com.nicholasrutherford.distractme.activitys
 
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
 import androidx.appcompat.app.AppCompatActivity
+import com.nicholasrutherford.distractme.R
+
+/**
+ * Created by Nick R.
+ */
 
 class SplashActivity : AppCompatActivity() {
-}
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_splash)
+        delayHandlerForSplash()
+    }
+
+    private fun startUpMainActivity() {
+        val intent: Intent = Intent(applicationContext, MainActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun delayHandlerForSplash() {
+        val handler = Handler()
+        handler.postDelayed({
+            startUpMainActivity()
+        }, 5000)
+        }
+
+    }

--- a/code/app/src/main/res/layout/activity_main.xml
+++ b/code/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".activitys.MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"

--- a/code/app/src/main/res/layout/activity_splash.xml
+++ b/code/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/splashscreen"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorWhite"
+    android:orientation="vertical"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".activitys.SplashActivity"
+    tools:ignore="PrivateResource">
+
+    <TextView
+        android:id="@+id/tvSplashTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/app_name_splash_desc"
+        android:gravity="center"
+        android:text="@string/app_name"
+        android:textAlignment="center"
+        android:textColor="@color/colorPrimary"
+        android:textSize="90sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/values/colors.xml
+++ b/code/app/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="colorWhite">#FFFFFF</color>
     <color name="colorPrimary">#6200EE</color>
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#03DAC5</color>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">Distract Me</string>
-    <string name="tab_text_1">Tab 1</string>
-    <string name="tab_text_2">Tab 2</string>
+    <string name="app_name_splash_desc">This is the splash screen title, which is Distract Me.</string>
+    <string name="app_splash">Splash Screen For Distract Me</string>
+    <string name="tab_text_1">News</string>
+    <string name="tab_text_2">Saved News</string>
 </resources>


### PR DESCRIPTION
### Trello
https://trello.com/c/NXcSxDn8/9-develop-a-splash-screen-with-the-distract-me-logo

### Issues
There isn't a splash screen for the current app, that it falls back on when user opens the app. This splash screen should stay on the app for a couple of seconds, and then shift to the main screen. 

### Proposed Changes
Create a splash screen, that has the logo in the middle of the screen. After a couple of seconds, the app shifts to the `Main Activity`, screen. 

### TO-DO
Task itself is done, but will need to add a typeface to the title(which will be done right after this). 


### Screenshots

![Screenshot_20200321-123332_Distract Me](https://user-images.githubusercontent.com/30304972/77232701-e4a05780-6b5f-11ea-8141-a83f74ac061c.jpg)

