### PR TITLE
Added Typeface Sub Classes 

### DIFF
--- a/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.os.Handler
 import androidx.appcompat.app.AppCompatActivity
 import com.nicholasrutherford.distractme.R
+import com.nicholasrutherford.distractme.helpers.Typeface
+import kotlinx.android.synthetic.main.activity_splash.*
 
 /**
  * Created by Nick R.
@@ -12,10 +14,13 @@ import com.nicholasrutherford.distractme.R
 
 class SplashActivity : AppCompatActivity() {
 
+    private val typeface = Typeface()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
         delayHandlerForSplash()
+        setTypeFaceOfSplashTitle()
     }
 
     private fun startUpMainActivity() {
@@ -29,5 +34,9 @@ class SplashActivity : AppCompatActivity() {
             startUpMainActivity()
         }, 5000)
         }
+
+    private fun setTypeFaceOfSplashTitle() {
+        typeface.setTypefaceForHeaderBold(tvSplashTitle,applicationContext)
+    }
 
     }

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/helpers/Typeface.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/helpers/Typeface.kt
@@ -1,0 +1,39 @@
+package com.nicholasrutherford.distractme.helpers
+
+import android.content.Context
+import android.graphics.Typeface
+import android.widget.TextView
+
+class Typeface {
+
+    fun setTypefaceForHeaderRegular(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "Poppins-Regular.otf")
+        textViewType.typeface = typeface
+    }
+
+    fun setTypefaceForHeaderBold(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "Poppins-Bold.otf")
+        textViewType.typeface = typeface
+    }
+
+    fun setTypefaceForSubHeaderRegular(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "Raleway-Regular.ttf")
+        textViewType.typeface = typeface
+    }
+
+    fun setTypefaceForSubHeaderBold(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "Raleway-Bold.ttf")
+        textViewType.typeface = typeface
+    }
+
+    fun setTypefaceForBodyRegular(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "OpenSans-Regular.ttf")
+        textViewType.typeface = typeface
+    }
+
+    fun setTypefaceForBodyRegularBold(textViewType: TextView, mContext: Context) {
+        val typeface = Typeface.createFromAsset(mContext.assets, "OpenSans-Bold.ttf")
+        textViewType.typeface = typeface
+    }
+
+}


### PR DESCRIPTION
### Trello
https://trello.com/c/v6fHKe93/15-create-a-type-face-helper-class-in-order-to-develop-fonts-for-other-classes

### Issues
No way to call a method to set the desired typeface. 

Will have to set the typeface the following way: 

`val typeface = Typeface.createFromAsset(context.assets, "myfont.otf")`

`textView.typeface = typeface ` 

Opposed to just putting this base functionality in a method, and just calling the method itself with desired parameters. 

### Proposed Changes
Create sub-methods for each and every single typeface, in order to just call the said typeface 

For example: 

`val typeface = Typeface()`

`typeface.setTypefaceForHeaderBold(textview, context)`

### Additional Info
These methods will need to be called all the time, and in addition; changed splash screen to have header bold typeface. 

### Screenshots

![Screenshot_20200321-132517_Distract Me](https://user-images.githubusercontent.com/30304972/77233857-98591580-6b67-11ea-8200-3e0673edf367.jpg)

