### PR TITLE
fixed bug with filters with main news home update

### DIFF
--- a/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/activitys/SplashActivity.kt
@@ -26,6 +26,7 @@ class SplashActivity : AppCompatActivity() {
     private fun startUpMainActivity() {
         val intent: Intent = Intent(applicationContext, MainActivity::class.java)
         startActivity(intent)
+        finish()
     }
 
     private fun delayHandlerForSplash() {

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/fragments/Home.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/fragments/Home.kt
@@ -48,26 +48,39 @@ class Home : Fragment() {
         emit(result)
     }
 
+    private fun initAdapter() {
+        newsTopHeadlines.observe(viewLifecycleOwner, Observer {
+            articleAdapter = News(requireContext(), it)
+            rvHomes!!.adapter = articleAdapter
+        })
+    }
+
     private fun showTopHeadlines() {
-    //    if(articleAdapter == null) {
-            newsTopHeadlines.observe(viewLifecycleOwner, Observer {
-                articleAdapter = News(requireContext(), it)
-                rvHomes!!.adapter = articleAdapter
-            })
-     //  } //else {
-//            if (sharedPreference?.getBoolean("countryFilterByTopHeadlines",false)!!) {
-//                updateTopHeadlineCountry()
-//                rvHomes!!.adapter = articleAdapter
-//            } else if(sharedPreference?.getBoolean("sourceFilterByTopHeadlines", false)!!) {
-//                updateTopHeadlineSources()
-//                rvHomes!!.adapter = articleAdapter
-//            } else if(sharedPreference?.getBoolean("countryAndCategoryFilterByTopHeadlines",false)!!) {
-//                updateTopHeadlinesCountryAndCategory()
-//                rvHomes!!.adapter = articleAdapter
-//            } else if(sharedPreference?.getBoolean("subjectFilterByTopHeadlines", false)!!) {
-//                updateTopHeadlineBySubject()
-//                rvHomes!!.adapter = articleAdapter
-//        }
+        if (articleAdapter == null) {
+            initAdapter()
+        } else {
+            when {
+                sharedPreference?.getBoolean("countryFilterByTopHeadlines", false)!! -> {
+                    updateTopHeadlineCountry()
+                    rvHomes!!.adapter = articleAdapter
+                }
+                sharedPreference?.getBoolean("sourceFilterByTopHeadlines", false)!! -> {
+                    updateTopHeadlineSources()
+                    rvHomes!!.adapter = articleAdapter
+                }
+                sharedPreference?.getBoolean("countryAndCategoryFilterByTopHeadlines", false)!! -> {
+                    updateTopHeadlinesCountryAndCategory()
+                    rvHomes!!.adapter = articleAdapter
+                }
+                sharedPreference?.getBoolean("subjectFilterByTopHeadlines", false)!! -> {
+                    updateTopHeadlineBySubject()
+                    rvHomes!!.adapter = articleAdapter
+                }
+                else -> {
+                    initAdapter()
+                }
+            }
+        }
     }
 
     private fun updateTopHeadlineCountry() {


### PR DESCRIPTION
### Trello
https://trello.com/c/aXBVLWFZ/33-fix-for-filters-home-screen

### Issues
- When the adapter from the news home page gets reloaded, it crashes due to a null exception pointed to the shared prefs. 

### Proposed Changes
- Create functionality to just reset the adapter, if values all shared prefs are false. 

### TO-DO
Nothing or now. 
