### PR TITLE
nick/ Filter clean up

### DIFF
--- a/code/app/src/main/java/com/nicholasrutherford/distractme/fragments/Home.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/fragments/Home.kt
@@ -21,6 +21,7 @@ class Home : Fragment() {
     private val repository: NewsRepositoryImp = NewsRepositoryImp()
     private var mView: View? = null
     private var rvHomes: RecyclerView? = null
+    private var updatedNews: Boolean = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,14 +31,16 @@ class Home : Fragment() {
         mView = inflater.inflate(R.layout.fragment_home, container, false)
         rvHomes = mView!!.findViewById(R.id.rvHome)
         main()
+        println(updatedNews)
         return mView
     }
 
     private fun main() {
         val sharedPreference = PreferenceManager.getDefaultSharedPreferences(context)
-        var editor = sharedPreference.edit()
+        val editor = sharedPreference.edit()
         setUpArticleAdapter()
         showTopHeadlines(sharedPreference)
+        checkUpdatedNews(editor)
     }
 
     private fun setUpArticleAdapter() {
@@ -62,15 +65,15 @@ class Home : Fragment() {
             initAdapter(sharedPreference)
         } else {
             when {
-                sharedPreference.getBoolean("countryFilterByTopHeadlines", false) -> { // working
+                sharedPreference.getBoolean("countryFilterByTopHeadlines", false) -> {
                     updateTopHeadlineCountry(sharedPreference)
                     rvHomes!!.adapter = articleAdapter
                 }
-                sharedPreference.getBoolean("sourceFilterByTopHeadlines", false) -> { // working
+                sharedPreference.getBoolean("sourceFilterByTopHeadlines", false) -> {
                     updateTopHeadlineSources(sharedPreference)
                     rvHomes!!.adapter = articleAdapter
                 }
-                sharedPreference.getBoolean("countryAndCategoryFilterByTopHeadlines", false) -> { // wprking
+                sharedPreference.getBoolean("countryAndCategoryFilterByTopHeadlines", false) -> {
                     updateTopHeadlinesCountryAndCategory(sharedPreference)
                     rvHomes!!.adapter = articleAdapter
                 }
@@ -84,13 +87,24 @@ class Home : Fragment() {
                 }
                 else -> {
                     initAdapter(sharedPreference)
-                    println(sharedPreference.getBoolean("countryFilterByTopHeadlines",false))
                 }
             }
         }
     }
 
+    private fun checkUpdatedNews(editor:SharedPreferences.Editor) {
+        if(!updatedNews) {
+            editor.putBoolean("countryFilterByTopHeadlines",false)
+            editor.putBoolean("sourceFilterByTopHeadlines", false)
+            editor.putBoolean("countryAndCategoryFilterByTopHeadlines", false)
+            editor.putBoolean("subjectFilterByTopHeadlines", false)
+            editor.putBoolean("everythingGrabAllNewsBy", false)
+            editor.apply()
+        }
+    }
+
     private fun updateTopHeadlineCountry(sharedPreference: SharedPreferences) {
+        updatedNews = true
         val newsTopHeadlineByCountry = liveData(Dispatchers.IO) {
             val result = sharedPreference.getString("countrySelectedTopHeadlines", "")?.let {
                 repository.getNewsTopHeadlinesByCountry(
@@ -106,6 +120,7 @@ class Home : Fragment() {
     }
 
     private fun updateTopHeadlineSources(sharedPreference: SharedPreferences) {
+        updatedNews = true
         val newsTopHeadlineBySources = liveData(Dispatchers.IO) {
             val result = sharedPreference.getString("sourceSelectedTopHeadlines", "")?.let {
                 repository.getTopHeadlinesBySource(
@@ -120,6 +135,7 @@ class Home : Fragment() {
     }
 
     private fun updateTopHeadlinesCountryAndCategory(sharedPreference: SharedPreferences) {
+        updatedNews = true
         val newsTopHeadlinesCountryAndCategory = liveData(Dispatchers.IO) {
             val result = sharedPreference.getString("countrySelectedTopHeadlinesFilterTwo", "")?.let {
                 repository.getTopHeadlinesByCountryAndCategory(
@@ -135,6 +151,7 @@ class Home : Fragment() {
     }
 
     private fun updateTopHeadlineBySubject(sharedPreference: SharedPreferences) {
+        updatedNews = true
         val newsTopHeadlinesSubject = liveData(Dispatchers.IO) {
             val result = sharedPreference.getString("subjectSelectedTopHeadlines", "")?.let {
                 repository.getTopHeadlinesBySubject(it,"92d8c9e8d1a44be58676ee20051e3c77" )
@@ -147,6 +164,7 @@ class Home : Fragment() {
     }
 
     private fun updateEverythingAllBySubject(sharedPreference: SharedPreferences) {
+        updatedNews = true
         val everythingAllBySubject = liveData(Dispatchers.IO) {
             val result = sharedPreference.getString("everythingActualNewsString", "")?.let {
                 repository.getEverything(it,"92d8c9e8d1a44be58676ee20051e3c77" )

--- a/code/app/src/main/java/com/nicholasrutherford/distractme/viewholders/FilterByViewHolder.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/distractme/viewholders/FilterByViewHolder.kt
@@ -17,7 +17,6 @@ class FilterByViewHolder(itemView: View, private val mContext: Context) : Recycl
     private val nothingTitle: String = mContext.resources.getString(R.string.nothing)
     private val topHeadlinesTitle: String = mContext.resources.getString(R.string.top_headlines)
     private val everythingTitle : String = mContext.resources.getString(R.string.everything)
-    private val sourcesTitle : String = mContext.resources.getString(R.string.sources)
     private val headlinesByCountryTitle : String = mContext.resources.getString(R.string.top_headlines_by_country)
     private val headlinesBySourceTitle : String = mContext.resources.getString(R.string.top_headlines_by_source)
     private val headlinesByCountryAndCategoryTitle : String = mContext.resources.getString(R.string.top_headlines_by_country_and_category)
@@ -39,7 +38,7 @@ class FilterByViewHolder(itemView: View, private val mContext: Context) : Recycl
     private var categorySelected: String = "business"
 
     // spinner arrays
-    private val spinnerCategoryItems = arrayOf(nothingTitle, topHeadlinesTitle, everythingTitle, sourcesTitle)
+    private val spinnerCategoryItems = arrayOf(nothingTitle, topHeadlinesTitle, everythingTitle)
     private val spinnerCategoryOfNewsItems = arrayOf(categoryBusiness, categoryEntertainment, categoryGeneral, categoryHealth,
     categoryScience, categorySports, categoryTechnology)
     private val spinnerTopHeadlinesNewsItems = arrayOf(nothingTitle, headlinesByCountryTitle,
@@ -150,15 +149,6 @@ class FilterByViewHolder(itemView: View, private val mContext: Context) : Recycl
                         hideHeadLineCountriesFilterBy()
                         hideHeadlineCategoryFilterBy()
                         hideHeadlineSubjectFilterBy()
-                    }
-                    parent?.selectedItem.toString() == sourcesTitle -> {
-                        hideTopShowHeadlineNews()
-                        hideHeadlineCountriesFilterByOnly()
-                        hideHeadlinesSourceFilterBy()
-                        hideHeadLineCountriesFilterBy()
-                        hideHeadlineCategoryFilterBy()
-                        hideHeadlineSubjectFilterBy()
-                        hideEverythingGrabNews()
                     }
                 }
             }

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -13,7 +13,6 @@
     <!-- News Endpoint Filter By Strings -->
     <string name="top_headlines">Top Headlines</string>
     <string name="everything">Everything</string>
-    <string name="sources">Sources</string>
 
     <!-- Filter By Strings -->
     <string name="top_headlines_by_country">By Country</string>


### PR DESCRIPTION

### Trello
https://trello.com/c/xPV9ppyR/35-clean-up-filter-screen-func-and-also-find-a-way-to-clear-out-shared-preferences-if-re-loading-the-screen

### Issues
- No way to filter screen func, and no way to clear out shared preferences if re loading the screen.

### Proposed Changes
- Removed the sources by filter , since there is nothing to filter for that. 
- Created a method to check if user was first instance of the app, and if they are don't update info from `sharedPrefs`. 

### TO-DO
- Possibly in the settings screen ask the user if I want too save the Filter? Filters should be saved for next instance of the app if the user wants it, so maybe give the user a way to save that data?)since its already getting saved
